### PR TITLE
feat: hash password and add user update endpoint

### DIFF
--- a/models/password.js
+++ b/models/password.js
@@ -1,0 +1,17 @@
+import bcryptjs from "bcryptjs";
+
+async function hash(password) {
+  let rounds = process.env.NODE_ENV === "production" ? 14 : 1;
+  return await bcryptjs.hash(password, rounds);
+}
+
+async function compare(plainPassword, hashedPassword) {
+  return await bcryptjs.compare(plainPassword, hashedPassword);
+}
+
+const password = {
+  hash,
+  compare,
+};
+
+export default password;

--- a/models/user.js
+++ b/models/user.js
@@ -33,59 +33,12 @@ async function findOneByUsername(username) {
 }
 
 async function create(userInputValues) {
-  await validateUniqueEmail(userInputValues.email);
   await validateUniqueUsername(userInputValues.username);
+  await validateUniqueEmail(userInputValues.email);
   await hashPasswordInObject(userInputValues);
 
   const newUser = await runInsertQuery(userInputValues);
   return newUser;
-
-  async function validateUniqueEmail(email) {
-    const result = await database.query({
-      text: `
-    SELECT
-      email 
-    FROM
-      users
-    WHERE
-      LOWER(email) = LOWER($1)
-    ;`,
-      values: [email],
-    });
-
-    if (result.rowCount > 0) {
-      throw new ValidationError({
-        message: "O email informado já está sendo utilizado",
-        action: "Utilize outro email para realizar o cadastro",
-      });
-    }
-  }
-
-  async function validateUniqueUsername(username) {
-    const result = await database.query({
-      text: `
-    SELECT
-      username 
-    FROM
-      users
-    WHERE
-      LOWER(username) = LOWER($1)
-    ;`,
-      values: [username],
-    });
-
-    if (result.rowCount > 0) {
-      throw new ValidationError({
-        message: "O username informado já está sendo utilizado",
-        action: "Utilize outro username para realizar o cadastro",
-      });
-    }
-  }
-
-  async function hashPasswordInObject(userInputValues) {
-    const hashedPassword = await password.hash(userInputValues.password);
-    userInputValues.password = hashedPassword;
-  }
 
   async function runInsertQuery(userInputValues) {
     const result = await database.query({
@@ -108,9 +61,105 @@ async function create(userInputValues) {
   }
 }
 
+async function update(username, userInputValues) {
+  const userFound = await findOneByUsername(username);
+
+  if ("username" in userInputValues) {
+    const username = userInputValues.username.toLowerCase();
+    await validateUniqueUsername(username);
+  }
+
+  if ("email" in userInputValues) {
+    const email = userInputValues.email.toLowerCase();
+    await validateUniqueEmail(email);
+  }
+
+  if ("password" in userInputValues) {
+    await hashPasswordInObject(userInputValues);
+  }
+
+  const userWithNewValues = { ...userFound, ...userInputValues };
+  const updatedUser = await runUpdateQuery(userWithNewValues);
+  return updatedUser;
+
+  async function runUpdateQuery(userWithNewValues) {
+    const result = await database.query({
+      text: `
+      UPDATE
+        users
+      SET
+        username = $2,
+        email = $3,
+        password = $4,
+        updated_at = timezone('utc', now())
+      WHERE
+        id = $1
+      RETURNING
+        *
+    ;`,
+      values: [
+        userWithNewValues.id,
+        userWithNewValues.username,
+        userWithNewValues.email,
+        userWithNewValues.password,
+      ],
+    });
+
+    return result.rows[0];
+  }
+}
+
+async function validateUniqueUsername(username) {
+  const result = await database.query({
+    text: `
+    SELECT
+      username 
+    FROM
+      users
+    WHERE
+      LOWER(username) = LOWER($1)
+    ;`,
+    values: [username],
+  });
+
+  if (result.rowCount > 0) {
+    throw new ValidationError({
+      message: "O username informado já está sendo utilizado",
+      action: "Utilize outro username para realizar está operação",
+    });
+  }
+}
+
+async function validateUniqueEmail(email) {
+  const result = await database.query({
+    text: `
+  SELECT
+    email 
+  FROM
+    users
+  WHERE
+    LOWER(email) = LOWER($1)
+  ;`,
+    values: [email],
+  });
+
+  if (result.rowCount > 0) {
+    throw new ValidationError({
+      message: "O email informado já está sendo utilizado",
+      action: "Utilize outro email para realizar está operação",
+    });
+  }
+}
+
+async function hashPasswordInObject(userInputValues) {
+  const hashedPassword = await password.hash(userInputValues.password);
+  userInputValues.password = hashedPassword;
+}
+
 const user = {
   create,
   findOneByUsername,
+  update,
 };
 
 export default user;

--- a/models/user.js
+++ b/models/user.js
@@ -1,4 +1,5 @@
 import database from "infra/database.js";
+import password from "models/password.js";
 import { ValidationError, NotFoundError } from "infra/errors.js";
 
 async function findOneByUsername(username) {
@@ -34,6 +35,7 @@ async function findOneByUsername(username) {
 async function create(userInputValues) {
   await validateUniqueEmail(userInputValues.email);
   await validateUniqueUsername(userInputValues.username);
+  await hashPasswordInObject(userInputValues);
 
   const newUser = await runInsertQuery(userInputValues);
   return newUser;
@@ -78,6 +80,11 @@ async function create(userInputValues) {
         action: "Utilize outro username para realizar o cadastro",
       });
     }
+  }
+
+  async function hashPasswordInObject(userInputValues) {
+    const hashedPassword = await password.hash(userInputValues.password);
+    userInputValues.password = hashedPassword;
   }
 
   async function runInsertQuery(userInputValues) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "async-retry": "1.3.3",
+        "bcryptjs": "3.0.2",
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
@@ -3234,6 +3235,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/bl": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "async-retry": "1.3.3",
+    "bcryptjs": "3.0.2",
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -5,6 +5,7 @@ import user from "models/user.js";
 const router = createRouter();
 
 router.get(getHandler);
+router.patch(patchHandler);
 
 export default router.handler(controller.errorHandlers);
 
@@ -12,4 +13,12 @@ async function getHandler(request, response) {
   const username = request.query.username;
   const userFound = await user.findOneByUsername(username);
   return response.status(200).json(userFound);
+}
+
+async function patchHandler(request, response) {
+  const username = request.query.username;
+  const userInputValues = request.body;
+
+  const updatedUser = await user.update(username, userInputValues);
+  return response.status(200).json(updatedUser);
 }

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -78,7 +78,6 @@ describe("GET /api/v1/users/[username]", () => {
         updated_at: responseBody.updated_at,
       });
 
-      console.log("RESULTADO CREATED_AT:", responseBody.created_at);
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(Date.parse(responseBody.created_at)).not.toBeNaN();
       expect(Date.parse(responseBody.updated_at)).not.toBeNaN();

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -36,7 +36,7 @@ describe("GET /api/v1/users/[username]", () => {
         id: responseBody.id,
         username: "MesmoCase",
         email: "mesmo.case@teste.com",
-        password: "senha123",
+        password: responseBody.password,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
       });
@@ -73,7 +73,7 @@ describe("GET /api/v1/users/[username]", () => {
         id: responseBody.id,
         username: "CaseDiferente",
         email: "case.diferente@teste.com",
-        password: "senha123",
+        password: responseBody.password,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
       });

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -1,0 +1,338 @@
+import orchestrator from "tests/orchestrator.js";
+import { version as uuidVersion } from "uuid";
+import user from "models/user.js";
+import password from "models/password.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("PATCH /api/v1/users/[username]", () => {
+  describe("anonymous user", () => {
+    test("With nonexistent username", async () => {
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/inexistente",
+        {
+          method: "PATCH",
+        },
+      );
+
+      expect(response.status).toBe(404);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "NotFoundError",
+        message: "O username informado não foi encontrar no sistemas.",
+        action: "Verifique se o username está digitado corretamente.",
+        status_code: 404,
+      });
+    });
+
+    test("With duplicated 'username'", async () => {
+      const user1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usuario1",
+          email: "usuario1@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user1.status).toBe(201);
+
+      const user2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usuario2",
+          email: "usuario2@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user2.status).toBe(201);
+
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/usuario1",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            username: "usuario1",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "O username informado já está sendo utilizado",
+        action: "Utilize outro username para realizar está operação",
+        status_code: 400,
+      });
+    });
+
+    test("With 'username' Mixed Case", async () => {
+      const user1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usuario",
+          email: "usuario@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user1.status).toBe(201);
+
+      const user3 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usuario3",
+          email: "usuario3@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user3.status).toBe(201);
+
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/usuario",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            username: "UsuArio1",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "O username informado já está sendo utilizado",
+        action: "Utilize outro username para realizar está operação",
+        status_code: 400,
+      });
+    });
+
+    test("With duplicated 'email'", async () => {
+      const user4 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usuario4",
+          email: "usuario4@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user4.status).toBe(201);
+
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/usuario4",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: "usuario4@teste.com",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "O email informado já está sendo utilizado",
+        action: "Utilize outro email para realizar está operação",
+        status_code: 400,
+      });
+    });
+
+    test("With unique 'username'", async () => {
+      const user1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "usuarioUnique",
+          email: "usuarioUnique@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user1.status).toBe(201);
+
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/usuarioUnique",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            username: "usuarioUnique2",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "usuarioUnique2",
+        email: "usuarioUnique@teste.com",
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(responseBody.updated_at > responseBody.created_at).toBe(true);
+    });
+
+    test("With unique 'email'", async () => {
+      const user1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "UniqueEmail",
+          email: "UniqueEmail@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user1.status).toBe(201);
+
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/UniqueEmail",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: "UniqueEmail2@teste.com",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "UniqueEmail",
+        email: "UniqueEmail2@teste.com",
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(responseBody.updated_at > responseBody.created_at).toBe(true);
+    });
+
+    test("With new 'password'", async () => {
+      const user1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "newPassword",
+          email: "newPassword@teste.com",
+          password: "teste123",
+        }),
+      });
+
+      expect(user1.status).toBe(201);
+
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/newPassword",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            password: "newPassword2",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "newPassword",
+        email: "newPassword@teste.com",
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+      expect(responseBody.updated_at > responseBody.created_at).toBe(true);
+
+      const userInDatabase = await user.findOneByUsername("newPassword");
+
+      const correctPasswordMatch = await password.compare(
+        "newPassword2",
+        userInDatabase.password,
+      );
+
+      const IncorrectPasswordMatch = await password.compare(
+        "teste123",
+        userInDatabase.password,
+      );
+
+      expect(correctPasswordMatch).toBe(true);
+      expect(IncorrectPasswordMatch).toBe(false);
+    });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -78,7 +78,7 @@ describe("POST /api/v1/users", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          username: "usuario2",
+          username: "usuario4",
           email: "usuario2@teste.com",
           password: "abc123",
         }),
@@ -91,7 +91,7 @@ describe("POST /api/v1/users", () => {
       expect(response2Body).toEqual({
         name: "ValidationError",
         message: "O email informado já está sendo utilizado",
-        action: "Utilize outro email para realizar o cadastro",
+        action: "Utilize outro email para realizar está operação",
         status_code: 400,
       });
     });

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,5 +1,7 @@
 import { version as uuidVersion } from "uuid";
 import orchestrator from "tests/orchestrator.js";
+import user from "models/user.js";
+import password from "models/password.js";
 
 beforeAll(async () => {
   await orchestrator.waitForAllServices();
@@ -30,7 +32,7 @@ describe("POST /api/v1/users", () => {
         id: responseBody.id,
         username: "usuario",
         email: "usuario@teste.com",
-        password: "abc123",
+        password: responseBody.password,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
       });
@@ -38,6 +40,21 @@ describe("POST /api/v1/users", () => {
       expect(uuidVersion(responseBody.id)).toBe(4);
       expect(Date.parse(responseBody.created_at)).not.toBeNaN();
       expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      const userInDatabase = await user.findOneByUsername("usuario");
+
+      const correctPasswordMatch = await password.compare(
+        "abc123",
+        userInDatabase.password,
+      );
+
+      const IncorrectPasswordMatch = await password.compare(
+        "senha123",
+        userInDatabase.password,
+      );
+
+      expect(correctPasswordMatch).toBe(true);
+      expect(IncorrectPasswordMatch).toBe(false);
     });
 
     test("With duplicated 'email'", async () => {

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -130,7 +130,7 @@ describe("POST /api/v1/users", () => {
       expect(response2Body).toEqual({
         name: "ValidationError",
         message: "O username informado já está sendo utilizado",
-        action: "Utilize outro username para realizar o cadastro",
+        action: "Utilize outro username para realizar está operação",
         status_code: 400,
       });
     });


### PR DESCRIPTION
## Summary

- Install `bcryptjs` and create `password` model with `hash` and `compare` functions
- Hash password before saving on user creation
- Add `update` function to user model with validation for unique username/email and password re-hashing
- Add PATCH endpoint for updating users
- Add integration tests for PATCH endpoint

## Test plan

- [ ] POST /api/v1/users — password is stored hashed, hash verification passes
- [ ] PATCH /api/v1/users/[username] with nonexistent user returns 404
- [ ] PATCH with duplicated username/email returns 400
- [ ] PATCH with unique values returns 200 and updated data
- [ ] PATCH with new password — hash verification confirms correct password updated