### PR TITLE
test: add createUser helper to orchestrator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
         "@commitlint/config-conventional": "19.2.2",
+        "@faker-js/faker": "9.7.0",
         "commitizen": "4.3.0",
         "concurrently": "8.2.2",
         "cz-conventional-changelog": "3.3.0",
@@ -33,6 +34,7 @@
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-jest": "28.8.0",
         "husky": "9.1.4",
+        "i": "0.3.7",
         "jest": "29.6.2",
         "prettier": "3.3.3"
       }
@@ -875,6 +877,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
+      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5893,6 +5911,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@commitlint/cli": "19.4.0",
     "@commitlint/config-conventional": "19.2.2",
+    "@faker-js/faker": "9.7.0",
     "commitizen": "4.3.0",
     "concurrently": "8.2.2",
     "cz-conventional-changelog": "3.3.0",
@@ -47,6 +48,7 @@
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-jest": "28.8.0",
     "husky": "9.1.4",
+    "i": "0.3.7",
     "jest": "29.6.2",
     "prettier": "3.3.3"
   },

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -10,27 +10,19 @@ beforeAll(async () => {
 describe("GET /api/v1/users/[username]", () => {
   describe("anonymous user", () => {
     test("With exact case match", async () => {
-      const response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "MesmoCase",
-          email: "mesmo.case@teste.com",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        username: "MesmoCase",
+        email: "mesmo.case@teste.com",
+        password: "senha123",
       });
 
-      expect(response.status).toBe(201);
-
-      const response1 = await fetch(
+      const response = await fetch(
         "http://localhost:3000/api/v1/users/MesmoCase",
       );
 
-      expect(response1.status).toBe(200);
+      expect(response.status).toBe(200);
 
-      const responseBody = await response1.json();
+      const responseBody = await response.json();
 
       expect(responseBody).toEqual({
         id: responseBody.id,
@@ -47,27 +39,19 @@ describe("GET /api/v1/users/[username]", () => {
     });
 
     test("With case mismatch", async () => {
-      const response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "CaseDiferente",
-          email: "case.diferente@teste.com",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        username: "CaseDiferente",
+        email: "case.diferente@teste.com",
+        password: "senha123",
       });
 
-      expect(response.status).toBe(201);
-
-      const response1 = await fetch(
+      const response = await fetch(
         "http://localhost:3000/api/v1/users/casediferente",
       );
 
-      expect(response1.status).toBe(200);
+      expect(response.status).toBe(200);
 
-      const responseBody = await response1.json();
+      const responseBody = await response.json();
 
       expect(responseBody).toEqual({
         id: responseBody.id,

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -32,36 +32,16 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With duplicated 'username'", async () => {
-      const user1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "usuario1",
-          email: "usuario1@teste.com",
-          password: "teste123",
-        }),
+      await orchestrator.createUser({
+        username: "usuario1",
       });
 
-      expect(user1.status).toBe(201);
-
-      const user2 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "usuario2",
-          email: "usuario2@teste.com",
-          password: "teste123",
-        }),
+      await orchestrator.createUser({
+        username: "usuario2",
       });
-
-      expect(user2.status).toBe(201);
 
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/usuario1",
+        "http://localhost:3000/api/v1/users/usuario2",
         {
           method: "PATCH",
           headers: {
@@ -86,43 +66,23 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With 'username' Mixed Case", async () => {
-      const user1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "usuario",
-          email: "usuario@teste.com",
-          password: "teste123",
-        }),
+      await orchestrator.createUser({
+        username: "mixedCase",
       });
 
-      expect(user1.status).toBe(201);
-
-      const user3 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "usuario3",
-          email: "usuario3@teste.com",
-          password: "teste123",
-        }),
+      await orchestrator.createUser({
+        username: "mixedCase2",
       });
-
-      expect(user3.status).toBe(201);
 
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/usuario",
+        "http://localhost:3000/api/v1/users/mixedCase",
         {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            username: "UsuArio1",
+            username: "mIxedCase2",
           }),
         },
       );
@@ -140,29 +100,23 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With duplicated 'email'", async () => {
-      const user4 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "usuario4",
-          email: "usuario4@teste.com",
-          password: "teste123",
-        }),
+      await orchestrator.createUser({
+        email: "emailDuplicated@teste.com",
       });
 
-      expect(user4.status).toBe(201);
+      const user2 = await orchestrator.createUser({
+        email: "emailDuplicated2@teste.com",
+      });
 
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/usuario4",
+        `http://localhost:3000/api/v1/users/${user2.username}`,
         {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            email: "usuario4@teste.com",
+            email: "emailDuplicated@teste.com",
           }),
         },
       );
@@ -180,22 +134,12 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With unique 'username'", async () => {
-      const user1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "usuarioUnique",
-          email: "usuarioUnique@teste.com",
-          password: "teste123",
-        }),
+      const user1 = await orchestrator.createUser({
+        username: "usuarioUnique",
       });
 
-      expect(user1.status).toBe(201);
-
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/usuarioUnique",
+        `http://localhost:3000/api/v1/users/${user1.username}`,
         {
           method: "PATCH",
           headers: {
@@ -214,7 +158,7 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(responseBody).toEqual({
         id: responseBody.id,
         username: "usuarioUnique2",
-        email: "usuarioUnique@teste.com",
+        email: user1.email,
         password: responseBody.password,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
@@ -227,22 +171,12 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With unique 'email'", async () => {
-      const user1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "UniqueEmail",
-          email: "UniqueEmail@teste.com",
-          password: "teste123",
-        }),
+      const user1 = await orchestrator.createUser({
+        email: "UniqueEmail@teste.com",
       });
 
-      expect(user1.status).toBe(201);
-
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/UniqueEmail",
+        `http://localhost:3000/api/v1/users/${user1.username}`,
         {
           method: "PATCH",
           headers: {
@@ -260,7 +194,7 @@ describe("PATCH /api/v1/users/[username]", () => {
 
       expect(responseBody).toEqual({
         id: responseBody.id,
-        username: "UniqueEmail",
+        username: user1.username,
         email: "UniqueEmail2@teste.com",
         password: responseBody.password,
         created_at: responseBody.created_at,
@@ -274,29 +208,19 @@ describe("PATCH /api/v1/users/[username]", () => {
     });
 
     test("With new 'password'", async () => {
-      const user1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "newPassword",
-          email: "newPassword@teste.com",
-          password: "teste123",
-        }),
+      const user3 = await orchestrator.createUser({
+        password: "oldPassword",
       });
 
-      expect(user1.status).toBe(201);
-
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/newPassword",
+        `http://localhost:3000/api/v1/users/${user3.username}`,
         {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            password: "newPassword2",
+            password: "newPassword",
           }),
         },
       );
@@ -307,8 +231,8 @@ describe("PATCH /api/v1/users/[username]", () => {
 
       expect(responseBody).toEqual({
         id: responseBody.id,
-        username: "newPassword",
-        email: "newPassword@teste.com",
+        username: user3.username,
+        email: user3.email,
         password: responseBody.password,
         created_at: responseBody.created_at,
         updated_at: responseBody.updated_at,
@@ -319,15 +243,15 @@ describe("PATCH /api/v1/users/[username]", () => {
       expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
       expect(responseBody.updated_at > responseBody.created_at).toBe(true);
 
-      const userInDatabase = await user.findOneByUsername("newPassword");
+      const userInDatabase = await user.findOneByUsername(user3.username);
 
       const correctPasswordMatch = await password.compare(
-        "newPassword2",
+        "newPassword",
         userInDatabase.password,
       );
 
       const IncorrectPasswordMatch = await password.compare(
-        "teste123",
+        "oldPassword",
         userInDatabase.password,
       );
 

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,6 +1,8 @@
 import retry from "async-retry";
-import database from "infra/database";
+import database from "infra/database.js";
 import migrator from "models/migrator.js";
+import user from "models/user.js";
+import { faker } from "@faker-js/faker";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -29,10 +31,20 @@ async function runPendingMigrations() {
   await migrator.runPendingMigrations();
 }
 
+async function createUser(userObject) {
+  return await user.create({
+    username:
+      userObject.username || faker.internet.username().replace(/[_.-]/g, ""),
+    email: userObject.email || faker.internet.email(),
+    password: userObject.password || faker.internet.password(),
+  });
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
   runPendingMigrations,
+  createUser,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Summary

- Install `@faker-js/faker` for random test data generation
- Add `createUser` helper to orchestrator, using faker to auto-generate username, email and password when not provided
- Refactor GET and PATCH integration tests to use `orchestrator.createUser` instead of raw fetch calls, eliminating username/email collisions between tests